### PR TITLE
Make test runner work with --watch

### DIFF
--- a/bin/buildBlueprints.js
+++ b/bin/buildBlueprints.js
@@ -180,11 +180,12 @@ build(makeConfig(builds, extensions), function(stats) {
 
     var mochaInstance = notifyingMochaInstance();
     var addFileToMocha = mochaInstance.addFile.bind(mochaInstance);
-    var promises = [];
-    stats.assets.forEach(function(asset) {
-      promises.push(cachebustTestFile(asset.name).then(addFileToMocha));
-    });
-    Promise.all(promises).then(function() {
+
+    function prepareAssetForMocha(asset) {
+      return cachebustTestFile(asset.name).then(addFileToMocha);
+    }
+
+    Promise.all(stats.assets.map(prepareAssetForMocha)).then(function() {
       mochaInstance.run()
         .on('end', function() {
           removeCompiledTests(extensions.watch);

--- a/package.json
+++ b/package.json
@@ -38,19 +38,21 @@
     "babel-preset-stage-2": "^6.5.0",
     "css-loader": "^0.23.1",
     "extract-text-webpack-plugin": "^1.0.1",
+    "fs-extra": "^0.30.0",
     "glob": "^7.0.3",
     "ignore-loader": "^0.1.1",
     "json-loader": "^0.5.4",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
+    "mocha": "^2.4.5",
+    "mocha-notifier-reporter": "^0.1.1",
     "node-notifier": "^4.5.0",
     "postcss-loader": "^0.9.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
     "webfonts-generator": "^0.3.5",
     "webpack": "^2.1.0-beta.7",
-    "yargs": "^4.6.0",
-    "mocha": "^2.4.5"
+    "yargs": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
👓 @ajacksified @phil303 @nramadas 

Quick and dirty watcher for tests. I tested in modmail by adding `-w` to the test command and changing the tests and the files they were testing. Running to apartment hunting for now, lemmie know if this seems good for now
