### PR TITLE
Exit with a non-0 status code on build failure

### DIFF
--- a/bin/buildBlueprints.js
+++ b/bin/buildBlueprints.js
@@ -112,6 +112,14 @@ if (argv.watch) {
 }
 
 build(makeConfig(builds, extensions), function(stats) {
+  if (stats.errors && stats.errors.length > 0 && !argv.watch) {
+    console.log(colors.red(
+      'ERROR IN BUILD. Aborting.'
+    ));
+
+    process.exit(1);
+  }
+
   if (argv.runTest) {
     console.log(colors.magenta(
       '\n   ******************************' +


### PR DESCRIPTION
👓 @schwers 

Currently, travis is saying failed builds (for example, for file case mismatches) are green. Instead, let's exit with a non-0 status code, when we're not in `watch` mode.
