### PR TITLE
buildBlueprints refactor

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -10,11 +10,11 @@ const nodeEnv = process.env.NODE_ENV || 'development';
 module.exports = function(config, cb) {
   if (!cb) { cb = function() {}; }
   config.builds.forEach(function(build) {
-    exectuteBuild(build, cb);
+    executeBuild(build, cb);
   });
 }
 
-function exectuteBuild(build, cb) {
+function executeBuild(build, cb) {
   var compiler = webpack(build.webpackConfig);
   if (build.watch) {
     compiler.watch({}, function(err, stats) {

--- a/lib/makeBuild.js
+++ b/lib/makeBuild.js
@@ -10,16 +10,10 @@ var getExternals = generators.getExternals;
 
 
 function makeBuild(shortBuild) {
-  return buildObject(shortBuild.name,
-    shortBuild.watch,
-    parseWebpackConfig(shortBuild.webpack, shortBuild.name))
-}
-
-function buildObject(buildName, watch, webpackConfig) {
   return {
-    watch,
-    buildName,
-    webpackConfig,
+    buildName: shortBuild.name,
+    watch: shortBuild.watch,
+    webpackConfig: parseWebpackConfig(shortBuild.webpack, shortBuild.name),
   };
 }
 
@@ -84,7 +78,6 @@ function mapLoadNameOrUseSource(array, loader) {
 
 module.exports = {
   makeBuild,
-  buildObject,
   parseWebpackConfig,
   loadNameOrUseSource,
 };


### PR DESCRIPTION
I'm not a fan of the globals and side effects in our build step. It makes following the code more difficult than it has to be. I believe I simplified the flow of this a bit but definitely open to disagreement/other ideas.

In this patch:
- remove the global `build` and `extensions`
- made some functions pure
- some small typo fixes

:eyeglasses: @schwers
