### PR TITLE
Test watcher

### DIFF
--- a/bin/buildBlueprints.js
+++ b/bin/buildBlueprints.js
@@ -6,6 +6,7 @@ var debug = require('debug')('blueprints');
 var Mocha = require('mocha');
 var colors = require('colors');
 var rimraf = require('rimraf');
+var mochaNotifier = require('mocha-notifier-reporter');
 
 var build = require('../lib/build');
 var makeBuild = require('../lib/makeBuild').makeBuild;
@@ -134,7 +135,7 @@ build(config, function(stats) {
       '\n   ******************************'
     ));
 
-    m = new Mocha();
+    m = new Mocha({ reporter: mochaNotifier.decorate('spec') });
     stats.assets.forEach(function(asset) {
       m.addFile('./.test/' + asset.name);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@r/build",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "A webpack based build system that can make UMD modules, (soon)peer-dependent library builds, server 'binarys', or full client ready scripts",
   "scripts": {
     "lint": "eslint lib"

--- a/package.json
+++ b/package.json
@@ -43,14 +43,15 @@
     "json-loader": "^0.5.4",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
+    "mocha": "^2.4.5",
+    "mocha-notifier-reporter": "^0.1.1",
     "node-notifier": "^4.5.0",
     "postcss-loader": "^0.9.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
     "webfonts-generator": "^0.3.5",
     "webpack": "^2.1.0-beta.7",
-    "yargs": "^4.6.0",
-    "mocha": "^2.4.5"
+    "yargs": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
This is a slightly simpler version of Schwers' approach. I  believe this gets the job done in a terser manner but I'll let you, my humble reviewer, be the judge of that.

Personally, I don't like that we have to do write it this way. It feels hacky but I don't have a better solution without throwing more tools/code at the problem which is probably the worser of two evils. For now, the most important thing is getting a test watcher running then we can figure out another strategy if we need to.

Ryan, I stole your idea for cleaning up the leftover test files. It'd be great if this could all be done in memory which is how the mocha cli actually handles things (using `babel-register`) but I can't find a simple way of getting webpack to pass the code and then have mocha handle that directly.

:eyeglasses: @schwers @nramadas 
