### PR TITLE
Fix namespaced module resolution

### DIFF
--- a/lib/generators/externals/loadNodeModules.js
+++ b/lib/generators/externals/loadNodeModules.js
@@ -5,6 +5,17 @@ function prependCommonjs (modules, name) {
   return modules;
 }
 
+function reduceNamespaces (module) {
+  if (module.charAt(0) === '@') {
+    return (
+      fs.readdirSync('node_modules/' + module)
+        .map(function(m) { return module + '/' + m; })
+    );
+  }
+
+  return module;
+}
+
 var lodashSubmodules = [
   'array', 'collection', 'date', 'function', 'lang', 'math',
   'number', 'object', 'seq', 'string', 'util', 'properties', 'methods'
@@ -15,6 +26,7 @@ module.exports = function(additional) {
 
   fs.readdirSync('node_modules')
     .filter(function(x) { return ['.bin'].indexOf(x) === -1; })
+    .map(reduceNamespaces)
     .reduce(prependCommonjs, nodeModules);
 
   if (additional) {

--- a/lib/generators/externals/loadNodeModules.js
+++ b/lib/generators/externals/loadNodeModules.js
@@ -1,5 +1,13 @@
 var fs = require('fs');
 
+function flattenArrays(newArray, thingOrArray) {
+  if (Array.isArray(thingOrArray)) {
+    return newArray.concat(thingOrArray);
+  }
+
+  return newArray.concat([ thingOrArray ]);
+}
+
 function prependCommonjs (modules, name) {
   modules[name] = 'commonjs ' + name;
   return modules;
@@ -27,6 +35,7 @@ module.exports = function(additional) {
   fs.readdirSync('node_modules')
     .filter(function(x) { return ['.bin'].indexOf(x) === -1; })
     .map(reduceNamespaces)
+    .reduce(flattenArrays, []) // reduceNamespaces can return arrays so we need to flatten first
     .reduce(prependCommonjs, nodeModules);
 
   if (additional) {


### PR DESCRIPTION
The commonjs bundler used to prevent server-side builds from including
npm modules read the `node_modules` directory to create an array of
folder names to ignore. This had the effect of turning includes such as
`thing` into `commonjs thing`, but also turned namespaced modules such
as `@r/api-client` into `commonjs @r`, thus building the
dependency into the server-side build.

This reads namespaced (`@`-prefixed modules) folders and creates an
additional list of namespaced modules for the commonjs prefixer, so
`@r/api-client` becomes `commonjs @r/api-client`.

👓 @schwers 
