### PR TITLE
Fix versions numbers for extract-text-webpack-plugin and webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
     "css-loader": "^0.23.1",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "~2.0.0-beta",
     "glob": "^7.0.3",
     "ignore-loader": "^0.1.1",
     "json-loader": "^0.5.4",
@@ -50,7 +50,7 @@
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
     "webfonts-generator": "^0.3.5",
-    "webpack": "^2.1.0-beta.7",
+    "webpack": "~2.1.0-beta.17",
     "yargs": "^4.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Found an issue today where extract-text-webpack-plugin was failing with version 1.0.1. Upgrading it to 2.0.0-beta.1 resolved the issue. 

:eyeglasses: @schwers 
