### PR TITLE
Build webfonts with process.env.STATIC_BASE

### DIFF
--- a/bin/buildWebfonts.js
+++ b/bin/buildWebfonts.js
@@ -4,19 +4,18 @@ var path = require('path');
 var webfontsGenerator = require('webfonts-generator');
 
 var SRC = path.resolve('./assets/svg/*.svg');
+var ASSET_PATH = process.env.STATIC_BASE || '';
 
 glob(SRC, function(error, files) {
-  console.log('generating font from:\n', files);
-
   webfontsGenerator({
     files: files,
     dest: path.resolve('./assets/fonts'),
     fontName: 'rfont',
     css: true,
     cssDest: path.resolve('./assets/fonts/rfont.css'),
-    cssFontsUrl: '/fonts',
+    cssFontsUrl: ASSET_PATH + '/fonts',
     html: true,
     types: ['svg', 'ttf', 'woff', 'eot'],
     normalize: true,
-  })
+  });
 });


### PR DESCRIPTION
We had some issues building fonts in production, the url to request font files needs to either: have a url that's relative to our css file's public static path, or is an absolute url with the public static path. The cleanest solution I found was to use make absolute urls with the `STATIC_BASE` env variable the rest of the build system is using.

👓  @birakattack or @nramadas 
