### PR TITLE
Don't use the configs in project's filepath if options.runTest.

### DIFF
--- a/bin/buildBlueprints.js
+++ b/bin/buildBlueprints.js
@@ -99,7 +99,7 @@ function makeConfig(options) {
   var builds;
   var extensions = {};
 
-  if (options.blueprintsPath && !options.ignoreBlueprints) {
+  if (options.blueprintsPath && !options.ignoreBlueprints && !options.runTest) {
     var blueprints = loadBlueprintsFromPath(options.blueprintsPath, options.production);
 
     if (blueprints.extensions) {


### PR DESCRIPTION
The config loader has a bug that it ignores `options.runTest` if there is a `blueprints.config.js` in your project. This fixes that so we load the testing config that finds all of your tests to compile and run those in mocha. 

This broke for mweb when we started using custom configs because of production building (https://github.com/reddit/reddit-mobile/pull/653).

🔕  At some point in the future we may need to make the testing configs smarter. I.E. your project may have some custom config that it relies on that would prevent tests from compiling properly. 

👓  @nramadas or @uzi
