### PR TITLE
Resolve image and font urls relative to css location. And resolve node packages.

### DIFF
--- a/bin/buildWebfonts.js
+++ b/bin/buildWebfonts.js
@@ -4,7 +4,6 @@ var path = require('path');
 var webfontsGenerator = require('webfonts-generator');
 
 var SRC = path.resolve('./assets/svg/*.svg');
-var ASSET_PATH = process.env.STATIC_BASE || '';
 
 glob(SRC, function(error, files) {
   webfontsGenerator({
@@ -13,7 +12,7 @@ glob(SRC, function(error, files) {
     fontName: 'rfont',
     css: true,
     cssDest: path.resolve('./assets/fonts/rfont.css'),
-    cssFontsUrl: ASSET_PATH + '/fonts',
+    cssFontsUrl: '/fonts',
     html: true,
     types: ['svg', 'ttf', 'woff', 'eot'],
     normalize: true,

--- a/lib/configs/DefaultClientConfig.js
+++ b/lib/configs/DefaultClientConfig.js
@@ -1,6 +1,7 @@
 var ManifestPlugin = require('webpack-manifest-plugin');
 var fs = require('fs-extra');
 var path = require('path');
+var loaders = require('./clientLoaders');
 
 module.exports = {
   name: 'Client',
@@ -16,12 +17,7 @@ module.exports = {
       paths: ['src', 'lib'],
       extensions: ['', '.js', '.jsx', '.es6.js', '.json'],
     },
-    loaders: [
-      'esnextreact',
-      'json',
-      'css',
-      'less',
-    ],
+    loaders,
     plugins: [
       'extract-css',
       'abort-if-errors',

--- a/lib/configs/DefaultProductionClientConfig.js
+++ b/lib/configs/DefaultProductionClientConfig.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var ManifestPlugin = require('webpack-manifest-plugin');
+var loaders = require('./clientLoaders');
 
 module.exports = {
   name: 'ProductionClient',
@@ -14,14 +15,9 @@ module.exports = {
     resolve: {
       generator: 'npm-and-modules',
       paths: ['src', 'lib'],
-      extensions: ['', '.js', '.jsx', '.es6.js', '.json']
+      extensions: ['', '.js', '.jsx', '.es6.js', '.json'],
     },
-    loaders: [
-      'esnextreact',
-      'json',
-      'css',
-      'less',
-    ],
+    loaders,
     plugins: [
       {
         generator: 'clean-directories',

--- a/lib/configs/clientLoaders.js
+++ b/lib/configs/clientLoaders.js
@@ -1,0 +1,21 @@
+module.exports = [
+  'esnextreact',
+  'json',
+  'css',
+  // Enable less and tell webpack that our static asses all live in <project>/assets
+  {
+    generator: 'less',
+    assetsDirectory: 'assets',
+    publicPath: './',
+  },
+  // resolves webfonts urls, assumes they all live in <project>/assets/fonts
+  {
+    test: /\/fonts\/.*\.(eot|woff|ttf|svg)(\?.+)?$/,
+    loader: 'file?emitFile=false&name=fonts/[name].[ext]',
+  },
+  // resolves images as urls, assumes they all live in <project>/assets/img
+  {
+    test: /\/img\/.*\.(png|svg|jpe?g|gif|tiff)$/,
+    loader: 'file?emitFile=false&name=img/[name].[ext]',
+  },
+];

--- a/lib/generators/loaders/CSSLoader.js
+++ b/lib/generators/loaders/CSSLoader.js
@@ -1,6 +1,28 @@
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
+// CSSLoader allows you to write and import css from your javascript.
+// Use with ExtractCSSPlugin  (or manually via ExtractTextPlugin) to bundle the
+// css into a single stylesheet.
+//
+// You can pass `assetsDirectory` to tell webpack where your images live
+// This will enable webpack to search for and resolve those images through
+// other loaders like 'url-loader' and 'file-loader';
+// You can pass `publicPath` to add a public path prefix to resolved images.
 
-module.exports = {
-  test: /\.css$/,
-  loader: ExtractTextPlugin.extract({ notExtractLoader: 'style-loader', loader: 'css-loader!postcss-loader'}),
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var path = require('path');
+
+
+module.exports = function(options) {
+  var assetsDirectory = options.assetsDirectory;
+  var publicPath = options.publicPath;
+
+  var root = assetsDirectory ? '?root=' + path.join(process.cwd(), assetsDirectory) : '';
+
+  return {
+    test: /\.css$/,
+    loader: ExtractTextPlugin.extract({
+      fallbackLoader: 'style-loader',
+      loader: 'css-loader' + root + '!postcss-loader',
+      publicPath: publicPath,
+    }),
+  };
 };

--- a/lib/generators/loaders/ESNextReactLoader.js
+++ b/lib/generators/loaders/ESNextReactLoader.js
@@ -7,12 +7,12 @@ module.exports = {
       'es2015-native-modules',
       'stage-2',
       'react',
-    ],
+    ].map(function(p) { return require.resolve('babel-preset-' + p) }),
     plugins: [
       'transform-class-properties',
       'transform-react-constant-elements',
       'transform-react-inline-elements',
       'lodash', // fixes the babel budnling issue
-    ],
+    ].map(function(p) { return require.resolve('babel-plugin-' + p) }),
   }
 };

--- a/lib/generators/loaders/LessLoader.js
+++ b/lib/generators/loaders/LessLoader.js
@@ -1,6 +1,28 @@
+// Less loader allows you to write less and import those files in your jsx templates.
+// Use with ExtractCSSPlugin  (or manually via ExtractTextPlugin) to bundle the
+// css into a single stylesheet.
+//
+// You can pass `assetsDirectory` to tell webpack where your images live
+// This will enable webpack to search for and resolve those images through
+// other loaders like 'url-loader' and 'file-loader';
+// You can pass `publicPath` to add a public path prefix to resolved images.
+
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-module.exports = {
-  test: /\.less$/,
-  loader: ExtractTextPlugin.extract({ notExtractLoader: 'style-loader', loader: 'css-loader!postcss-loader!less-loader'}),
+var path = require('path');
+
+module.exports = function(options) {
+  var assetsDirectory = options.assetsDirectory;
+  var publicPath = options.publicPath;
+
+  var root = assetsDirectory ? '?root=' + path.join(process.cwd(), assetsDirectory) : '';
+
+  return {
+    test: /\.less$/,
+    loader: ExtractTextPlugin.extract({
+      fallbackLoader: 'style-loader',
+      loader: 'css-loader' + root + '!postcss-loader!less-loader',
+      publicPath,
+    }),
+  };
 };

--- a/lib/generators/plugins/ExtractCSSPlugin.js
+++ b/lib/generators/plugins/ExtractCSSPlugin.js
@@ -4,9 +4,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 // filename will contain a content hash for cache-busing. If you go that route
 // you should use a manifest plugin like 'webpack-manifest-plugin'.
 module.exports = function(options) {
-  if (options.contenthash) {
-    return new ExtractTextPlugin('[name].[contenthash].css');
-  }
-
-  return new ExtractTextPlugin('[name].css');
+  return new ExtractTextPlugin({
+    filename: options.contenthash ? '[name].[contenthash].css' : '[name].css',
+  });
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
     "css-loader": "^0.23.1",
-    "extract-text-webpack-plugin": "~2.0.0-beta",
+    "extract-text-webpack-plugin": "~2.0.0-beta.3",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.3",
     "ignore-loader": "^0.1.1",


### PR DESCRIPTION
There's two commits here. The first fixes image and font url resolution. I found out the problem I encountered was just a misunderstanding of the `css-loader` and `file-loader` docs. This patch makes it some images in your css are re-written to urls relative to your css. 

It assumes your assets like images and fonts are located in `assets/img` and `assets/fonts`. I'd be open to making it more configureable but this PR can at least get the basic idea across. 

The second patch, that we all know and love, is the module resolution of npm-link'd packages locally. I figured I'd include it so we can try that out on snoo guts.

👓 @nramadas 
