### PR TITLE
Revert "Revert "Fix module resolution for npm-link'd packages""

### DIFF
--- a/lib/generators/loaders/ESNextReactLoader.js
+++ b/lib/generators/loaders/ESNextReactLoader.js
@@ -7,12 +7,12 @@ module.exports = {
       'es2015-native-modules',
       'stage-2',
       'react',
-    ],
+    ].map(function(p) { return require.resolve('babel-preset-' + p) }),
     plugins: [
       'transform-class-properties',
       'transform-react-constant-elements',
       'transform-react-inline-elements',
       'lodash', // fixes the babel budnling issue
-    ],
+    ].map(function(p) { return require.resolve('babel-plugin-' + p) }),
   }
 };


### PR DESCRIPTION
This reverts commit 8dc3d9b82be05fe3077e2cc82963a229858930b5.

Commit 93e5e1b fixes the issue, so we should be ok putting the `require.resolve` back in

:eyeglasses: @schwers || @phil303 
