### PR TITLE
Fix Sourcemaps

### DIFF
--- a/lib/generators/output/ContentHashOutput.js
+++ b/lib/generators/output/ContentHashOutput.js
@@ -8,6 +8,6 @@ module.exports = function(options) {
   return {
     path: path.join(process.cwd(), options.dest),
     filename: '[name].[chunkhash].js',
-    sourceMapFilename: '[name].[chunkhash].js.map',
+    sourceMapFilename: '[file].map',
   };
 };

--- a/lib/output/SimpleOutput.js
+++ b/lib/output/SimpleOutput.js
@@ -4,6 +4,6 @@ module.exports = function(options){
   return {
     path: path.join(process.cwd(), options.dest),
     filename: options.name || '[name].js',
-    sourceMapFilename: '[name].js.map',
+    sourceMapFilename: '[file].map',
   };
 };


### PR DESCRIPTION
The ExtractTextPlugin has a bug that breaks
sourcemaps when you don't use [file].

👓  @schwers @phil303 
