### PR TITLE
Make the api to the DefinePlugin wrapper more flexible

### DIFF
--- a/lib/configs/DefaultClientConfig.js
+++ b/lib/configs/DefaultClientConfig.js
@@ -23,7 +23,7 @@ module.exports = {
       'abort-if-errors',
       {
         generator: 'set-node-env',
-        env: 'client',
+        'process.env': { ENV: JSON.stringify('client') },
       },
       new ManifestPlugin(),
     ],

--- a/lib/configs/DefaultProductionClientConfig.js
+++ b/lib/configs/DefaultProductionClientConfig.js
@@ -29,7 +29,7 @@ module.exports = {
       },
       {
         generator: 'set-node-env',
-        env: 'client',
+        'process.env': { ENV: JSON.stringify('client') },
       },
       'production-loaders',
       'minify-and-treeshake',

--- a/lib/generators/plugins/SetNodeEnvironmentPlugin.js
+++ b/lib/generators/plugins/SetNodeEnvironmentPlugin.js
@@ -1,13 +1,14 @@
 var webpack = require('webpack');
+var merge = require('lodash/merge');
 
-var nodeEnv = process.env.NODE_ENV || 'production';
-var env = process.env.ENV || 'server';
 
 module.exports = function(options) {
-  return new webpack.DefinePlugin({
+  const pluginOptions = merge({
     'process.env': {
-      NODE_ENV: JSON.stringify(options.nodeEnv || nodeEnv),
-      ENV: JSON.stringify(options.env || env),
+      NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'production'),
+      ENV: JSON.stringify(process.env.ENV || 'server'),
     },
-  });
+  }, options);
+
+  return new webpack.DefinePlugin(pluginOptions);
 };

--- a/lib/generators/tryToLoadGenerator.js
+++ b/lib/generators/tryToLoadGenerator.js
@@ -26,7 +26,7 @@ function parseNameOrObject(nameOrObject) {
   if (typeof nameOrObject === 'object') {
     var name = nameOrObject.generator;
     if (typeof name === 'string') {
-      return { name, options: _.omit(nameOrObject, 'name') };
+      return { name, options: _.omit(nameOrObject, 'generator') };
     }
   }
 }


### PR DESCRIPTION
Problem:
The only thing you can set now is NODE_ENV and ENV inside
process.env, but I'd like to be able to set anything.

Fix:
Have the define plugin wrapper function take an options object
that it can then merge with the default options. This gets
passed into the DefinePlugin constructor directly.

Additional notes:
- There was a small bug in `parseNameOrObject` in
  `tryToLoadGenerator.js`. A reference to the wrong options key,
  'name', has been updated to be the correct one, 'generator'.

:eyeglasses: @schwers 
